### PR TITLE
Extend `AttributePageWhereInput` to allow filtering by assigned references

### DIFF
--- a/saleor/graphql/account/tests/mutations/authentication/test_request_password_reset.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_request_password_reset.py
@@ -1,5 +1,4 @@
 import datetime
-import warnings
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -557,10 +556,7 @@ def test_account_reset_password_no_channel_provided_one_channel(
     }
 
     # when
-    # Catch deprecation warning for missing channel slug
-    # This is to ensure that the warning is not raised in the test output.
-    with warnings.catch_warnings(record=True):
-        response = api_client.post_graphql(REQUEST_PASSWORD_RESET_MUTATION, variables)
+    response = api_client.post_graphql(REQUEST_PASSWORD_RESET_MUTATION, variables)
     content = get_graphql_content(response)
 
     # then

--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -1,12 +1,15 @@
+from typing import Literal, TypedDict
+
 import django_filters
 import graphene
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q, QuerySet
 
 from ...attribute import AttributeInputType
-from ...attribute.models import Attribute, AttributeValue
+from ...attribute.models import AssignedPageAttributeValue, Attribute, AttributeValue
 from ...channel.models import Channel
+from ...page import models as page_models
 from ...permission.utils import has_one_of_permissions
-from ...product import models
+from ...product import models as product_models
 from ...product.models import ALL_PRODUCTS_PERMISSIONS
 from ..channel.filters import get_channel_slug_from_filter_data
 from ..core.doc_category import DOC_CATEGORY_ATTRIBUTES
@@ -31,10 +34,8 @@ from ..core.filters.where_input import (
     StringFilterInput,
     WhereInputObjectType,
 )
-from ..core.types import (
-    BaseInputObjectType,
-    NonNullList,
-)
+from ..core.types.base import BaseInputObjectType
+from ..core.types.common import NonNullList
 from ..core.utils import from_global_id_or_error
 from ..utils import get_user_or_app_from_context
 from ..utils.filters import filter_by_ids, filter_slug_list, filter_where_by_value_field
@@ -49,13 +50,15 @@ def filter_attributes_by_product_types(qs, field, value, requestor, channel_slug
     if channel_slug is not None:
         channel = Channel.objects.using(qs.db).filter(slug=str(channel_slug)).first()
     limited_channel_access = False if channel_slug is None else True
-    product_qs = models.Product.objects.using(qs.db).visible_to_user(
+    product_qs = product_models.Product.objects.using(qs.db).visible_to_user(
         requestor, channel, limited_channel_access
     )
 
     if field == "in_category":
         _type, category_id = from_global_id_or_error(value, "Category")
-        category = models.Category.objects.using(qs.db).filter(pk=category_id).first()
+        category = (
+            product_models.Category.objects.using(qs.db).filter(pk=category_id).first()
+        )
 
         if category is None:
             return qs.none()
@@ -330,3 +333,352 @@ class AttributeValueWhereInput(WhereInputObjectType):
         filterset_class = AttributeValueWhere
         description = "Where filtering options for attribute values."
         doc_category = DOC_CATEGORY_ATTRIBUTES
+
+
+CONTAINS_TYPING = dict[Literal["contains_any", "contains_all"], list[str]]
+
+
+class SharedContainsFilterParams(TypedDict):
+    attr_id: int | None
+    db_connection_name: str
+    assigned_attr_model: type[AssignedPageAttributeValue]
+    assigned_id_field_name: Literal["page_id"]
+    identifier_field_name: Literal["slug", "id", "sku"]
+
+
+def filter_by_contains_referenced_object_ids(
+    attr_id: int | None,
+    attr_value: CONTAINS_TYPING,
+    db_connection_name: str,
+    assigned_attr_model: type[AssignedPageAttributeValue],
+    assigned_id_field_name: Literal["page_id"],
+):
+    """Build a filter expression for objects referencing other entities by global IDs.
+
+    Returns a Q expression to filter objects based on their references
+    to other entities (like: variants, products, pages), identified by
+    global IDs.
+
+    - If `contains_all` is provided, only objects that reference all of the
+    specified global IDs will match.
+    - If `contains_any` is provided, objects that reference at least one of
+    the specified global IDs will match.
+    """
+
+    contains_all = attr_value.get("contains_all")
+    contains_any = attr_value.get("contains_any")
+
+    variant_ids = set()
+    product_ids = set()
+    page_ids = set()
+
+    for obj_id in contains_any or contains_all or []:
+        type_, id_ = graphene.Node.from_global_id(obj_id)
+        if type_ == "Page":
+            page_ids.add(id_)
+        elif type_ == "Product":
+            product_ids.add(id_)
+        elif type_ == "ProductVariant":
+            variant_ids.add(id_)
+
+    expression = Q()
+    shared_filter_params: SharedContainsFilterParams = {
+        "attr_id": attr_id,
+        "db_connection_name": db_connection_name,
+        "assigned_attr_model": assigned_attr_model,
+        "assigned_id_field_name": assigned_id_field_name,
+        "identifier_field_name": "id",
+    }
+    if contains_all:
+        if page_ids:
+            expression &= _filter_contains_all_condition(
+                contains_all=list(page_ids),
+                referenced_model=page_models.Page,
+                attr_value_reference_field_name="reference_page_id",
+                **shared_filter_params,
+            )
+        if product_ids:
+            expression &= _filter_contains_all_condition(
+                contains_all=list(product_ids),
+                referenced_model=product_models.Product,
+                attr_value_reference_field_name="reference_product_id",
+                **shared_filter_params,
+            )
+        if variant_ids:
+            expression &= _filter_contains_all_condition(
+                contains_all=list(variant_ids),
+                referenced_model=product_models.ProductVariant,
+                attr_value_reference_field_name="reference_variant_id",
+                **shared_filter_params,
+            )
+        return expression
+
+    if contains_any:
+        if page_ids:
+            expression |= _filter_contains_any_condition(
+                contains_any=list(page_ids),
+                referenced_model=page_models.Page,
+                attr_value_reference_field_name="reference_page_id",
+                **shared_filter_params,
+            )
+
+        if product_ids:
+            expression |= _filter_contains_any_condition(
+                contains_any=list(product_ids),
+                referenced_model=product_models.Product,
+                attr_value_reference_field_name="reference_product_id",
+                **shared_filter_params,
+            )
+
+        if variant_ids:
+            expression |= _filter_contains_any_condition(
+                contains_any=list(variant_ids),
+                referenced_model=product_models.ProductVariant,
+                attr_value_reference_field_name="reference_variant_id",
+                **shared_filter_params,
+            )
+    return expression
+
+
+def _filter_contains_single_expression(
+    attr_id: int | None,
+    db_connection_name: str,
+    reference_objs: QuerySet[
+        page_models.Page | product_models.Product | product_models.ProductVariant
+    ],
+    attr_value_reference_field_name: Literal[
+        "reference_page_id", "reference_product_id", "reference_variant_id"
+    ],
+    assigned_attr_model: type[AssignedPageAttributeValue],
+    assigned_id_field_name: Literal["page_id"],
+):
+    single_reference_qs = AttributeValue.objects.using(db_connection_name).filter(
+        Exists(reference_objs.filter(id=OuterRef(attr_value_reference_field_name))),
+    )
+    if attr_id:
+        attr_query = Attribute.objects.using(db_connection_name).filter(id=attr_id)
+        single_reference_qs = single_reference_qs.filter(
+            Exists(attr_query.filter(id=OuterRef("attribute_id"))),
+        )
+    assigned_attr_value = assigned_attr_model.objects.using(db_connection_name).filter(
+        Exists(single_reference_qs.filter(id=OuterRef("value_id"))),
+        **{str(assigned_id_field_name): OuterRef("id")},
+    )
+    return Q(Exists(assigned_attr_value))
+
+
+def _filter_contains_all_condition(
+    attr_id: int | None,
+    db_connection_name: str,
+    contains_all: list[str],
+    assigned_attr_model: type[AssignedPageAttributeValue],
+    assigned_id_field_name: Literal["page_id"],
+    identifier_field_name: Literal["slug", "id", "sku"],
+    referenced_model: type[
+        page_models.Page | product_models.Product | product_models.ProductVariant
+    ],
+    attr_value_reference_field_name: Literal[
+        "reference_page_id", "reference_product_id", "reference_variant_id"
+    ],
+):
+    """Build a filter expression that ensures all specified references are present.
+
+    Constructs a Q expression that checks for references to all entities from
+    `referenced_model`, matched using the provided identifiers in `contains_all`.
+
+    For each identifier, it resolves the corresponding object using
+    `identifier_field_name` and adds a subquery to verify the presence
+    of that reference. The subqueries are combined using logical AND.
+    """
+
+    identifiers = contains_all
+    expression = Q()
+
+    for identifier in identifiers:
+        reference_obj = referenced_model.objects.using(db_connection_name).filter(
+            **{str(identifier_field_name): identifier}
+        )
+        expression &= _filter_contains_single_expression(
+            attr_id,
+            db_connection_name,
+            reference_obj,
+            attr_value_reference_field_name,
+            assigned_attr_model,
+            assigned_id_field_name,
+        )
+    return expression
+
+
+def _filter_contains_any_condition(
+    attr_id: int | None,
+    db_connection_name: str,
+    contains_any: list[str],
+    assigned_attr_model: type[AssignedPageAttributeValue],
+    assigned_id_field_name: Literal["page_id"],
+    identifier_field_name: Literal["slug", "id", "sku"],
+    referenced_model: type[
+        page_models.Page | product_models.Product | product_models.ProductVariant
+    ],
+    attr_value_reference_field_name: Literal[
+        "reference_page_id", "reference_product_id", "reference_variant_id"
+    ],
+):
+    """Build a filter expression that ensures at least one specified reference is present.
+
+    Constructs a Q expression that checks for a reference to any entity from
+    `referenced_model`, matched using the provided identifiers in `contains_any`.
+
+    All matching references are resolved using `identifier_field_name`,
+    and passed as a single queryset to be checked in a single subquery.
+
+    """
+    identifiers = contains_any
+    reference_objs = referenced_model.objects.using(db_connection_name).filter(
+        **{f"{identifier_field_name}__in": identifiers}
+    )
+    return _filter_contains_single_expression(
+        attr_id,
+        db_connection_name,
+        reference_objs,
+        attr_value_reference_field_name,
+        assigned_attr_model,
+        assigned_id_field_name,
+    )
+
+
+def filter_by_contains_referenced_pages(
+    attr_id: int | None,
+    attr_value: CONTAINS_TYPING,
+    db_connection_name: str,
+    assigned_attr_model: type[AssignedPageAttributeValue],
+    assigned_id_field_name: Literal["page_id"],
+):
+    """Build a filter expression for referenced pages.
+
+    Returns a Q expression to filter objects based on their references
+    to pages.
+
+    - If `contains_all` is provided, only objects that reference all of the
+    specified pages will match.
+    - If `contains_any` is provided, objects that reference at least one of
+    the specified pages will match.
+    """
+    contains_all = attr_value.get("contains_all")
+    contains_any = attr_value.get("contains_any")
+
+    shared_filter_params: SharedContainsFilterParams = {
+        "attr_id": attr_id,
+        "db_connection_name": db_connection_name,
+        "assigned_attr_model": assigned_attr_model,
+        "assigned_id_field_name": assigned_id_field_name,
+        "identifier_field_name": "slug",
+    }
+    if contains_all:
+        return _filter_contains_all_condition(
+            contains_all=contains_all,
+            referenced_model=page_models.Page,
+            attr_value_reference_field_name="reference_page_id",
+            **shared_filter_params,
+        )
+
+    if contains_any:
+        return _filter_contains_any_condition(
+            contains_any=contains_any,
+            referenced_model=page_models.Page,
+            attr_value_reference_field_name="reference_page_id",
+            **shared_filter_params,
+        )
+    return Q()
+
+
+def filter_by_contains_referenced_products(
+    attr_id: int | None,
+    attr_value: CONTAINS_TYPING,
+    db_connection_name: str,
+    assigned_attr_model: type[AssignedPageAttributeValue],
+    assigned_id_field_name: Literal["page_id"],
+):
+    """Build a filter expression for referenced products.
+
+    Returns a Q expression to filter objects based on their references
+    to products.
+
+    - If `contains_all` is provided, only objects that reference all of the
+    specified products will match.
+    - If `contains_any` is provided, objects that reference at least one of
+    the specified products will match.
+    """
+    contains_all = attr_value.get("contains_all")
+    contains_any = attr_value.get("contains_any")
+
+    shared_filter_params: SharedContainsFilterParams = {
+        "attr_id": attr_id,
+        "db_connection_name": db_connection_name,
+        "assigned_attr_model": assigned_attr_model,
+        "assigned_id_field_name": assigned_id_field_name,
+        "identifier_field_name": "slug",
+    }
+
+    if contains_all:
+        return _filter_contains_all_condition(
+            contains_all=contains_all,
+            referenced_model=product_models.Product,
+            attr_value_reference_field_name="reference_product_id",
+            **shared_filter_params,
+        )
+
+    if contains_any:
+        return _filter_contains_any_condition(
+            contains_any=contains_any,
+            referenced_model=product_models.Product,
+            attr_value_reference_field_name="reference_product_id",
+            **shared_filter_params,
+        )
+    return Q()
+
+
+def filter_by_contains_referenced_variants(
+    attr_id: int | None,
+    attr_value: CONTAINS_TYPING,
+    db_connection_name: str,
+    assigned_attr_model: type[AssignedPageAttributeValue],
+    assigned_id_field_name: Literal["page_id"],
+):
+    """Build a filter expression for referenced product variants.
+
+    Returns a Q expression to filter objects based on their references
+    to product variants.
+
+    - If `contains_all` is provided, only objects that reference all of the
+    specified variants will match.
+    - If `contains_any` is provided, objects that reference at least one of
+    the specified variants will match.
+    """
+
+    contains_all = attr_value.get("contains_all")
+    contains_any = attr_value.get("contains_any")
+
+    shared_filter_params: SharedContainsFilterParams = {
+        "attr_id": attr_id,
+        "db_connection_name": db_connection_name,
+        "assigned_attr_model": assigned_attr_model,
+        "assigned_id_field_name": assigned_id_field_name,
+        "identifier_field_name": "sku",
+    }
+
+    if contains_all:
+        return _filter_contains_all_condition(
+            contains_all=contains_all,
+            referenced_model=product_models.ProductVariant,
+            attr_value_reference_field_name="reference_variant_id",
+            **shared_filter_params,
+        )
+
+    if contains_any:
+        return _filter_contains_any_condition(
+            contains_any=contains_any,
+            referenced_model=product_models.ProductVariant,
+            attr_value_reference_field_name="reference_variant_id",
+            **shared_filter_params,
+        )
+    return Q()

--- a/saleor/graphql/core/filters/where_input.py
+++ b/saleor/graphql/core/filters/where_input.py
@@ -56,6 +56,8 @@ class FilterInputDescriptions:
     ONE_OF = "The value included in."
     NOT_ONE_OF = "The value not included in."
     RANGE = "The value in range."
+    CONTAINS_ALL = "The field contains all of the specified values."
+    CONTAINS_ANY = "The field contains at least one of the specified values."
 
 
 class StringFilterInput(graphene.InputObjectType):
@@ -182,3 +184,21 @@ class MetadataFilterInput(graphene.InputObjectType):
         - `{key: "status", value: {eq: "active"}}`
           Matches objects where the metadata key "status" is set to "active".
         """
+
+
+class ContainsFilterInput(graphene.InputObjectType):
+    contains_any = NonNullList(
+        graphene.String,
+        description=FilterInputDescriptions.CONTAINS_ANY,
+        required=False,
+    )
+    contains_all = NonNullList(
+        graphene.String,
+        description=FilterInputDescriptions.CONTAINS_ALL,
+        required=False,
+    )
+
+    class Meta:
+        description = (
+            "Define the filtering options for fields that can contain multiple values."
+        )

--- a/saleor/graphql/order/tests/benchmark/test_fulfillment_refund_and_return_products.py
+++ b/saleor/graphql/order/tests/benchmark/test_fulfillment_refund_and_return_products.py
@@ -10,7 +10,7 @@ from ....tests.utils import get_graphql_content
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_refund_products_order_lines(
     mocked_refund,
     staff_api_client,
@@ -71,7 +71,7 @@ def test_fulfillment_refund_products_order_lines(
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_return_products_order_lines(
     mocked_refund,
     back_in_stock_webhook_mock,

--- a/saleor/graphql/order/tests/deprecated/test_order.py
+++ b/saleor/graphql/order/tests/deprecated/test_order.py
@@ -319,7 +319,7 @@ mutation OrderFulfillmentRefundProducts(
 """
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_refund_products_order_lines_by_old_id(
     mocked_refund,
     staff_api_client,
@@ -428,7 +428,7 @@ mutation OrderFulfillmentReturnProducts(
 """
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_return_products_order_lines_by_old_line_id(
     mocked_refund,
     staff_api_client,

--- a/saleor/graphql/order/tests/mutations/test_fulfillment_refund_products.py
+++ b/saleor/graphql/order/tests/mutations/test_fulfillment_refund_products.py
@@ -79,7 +79,7 @@ def test_fulfillment_refund_products_by_user_no_channel_access(
     assert_no_permission(response)
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_refund_products_with_action_requested_by_app(
     mocked_refund,
     app_api_client,
@@ -126,7 +126,7 @@ def test_fulfillment_refund_products_with_action_requested_by_app(
     )
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
 def test_fulfillment_refund_products_with_back_in_stock_webhook(
     back_in_stock_webhook_trigger,
@@ -217,7 +217,7 @@ def test_fulfillment_refund_products_order_without_payment(
     assert fulfillment is None
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_refund_products_amount_and_shipping_costs(
     mocked_refund,
     staff_api_client,
@@ -286,7 +286,7 @@ def test_fulfillment_refund_products_amount_costs_for_order_with_gift_card_lines
     assert errors[0]["field"] == "amountToRefund"
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_refund_products_refund_raising_payment_error(
     mocked_refund,
     staff_api_client,
@@ -320,7 +320,7 @@ def test_fulfillment_refund_products_refund_raising_payment_error(
     assert errors[0]["code"] == OrderErrorCode.CANNOT_REFUND.name
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_refund_products_order_lines(
     mocked_refund,
     staff_api_client,
@@ -427,7 +427,7 @@ def test_fulfillment_refund_products_order_lines_quantity_bigger_than_unfulfille
     assert refund_fulfillment is None
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_refund_products_fulfillment_lines(
     mocked_refund,
     staff_api_client,
@@ -484,7 +484,7 @@ def test_fulfillment_refund_products_fulfillment_lines(
     )
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_refund_products_waiting_fulfillment_lines(
     mocked_refund,
     staff_api_client,
@@ -657,7 +657,7 @@ def test_fulfillment_refund_products_amount_bigger_than_captured_amount(
     assert refund_fulfillment is None
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_refund_products_fulfillment_lines_include_shipping_costs(
     mocked_refund,
     staff_api_client,
@@ -715,7 +715,7 @@ def test_fulfillment_refund_products_fulfillment_lines_include_shipping_costs(
     )
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_refund_products_order_lines_include_shipping_costs(
     mocked_refund,
     staff_api_client,
@@ -767,7 +767,7 @@ def test_fulfillment_refund_products_order_lines_include_shipping_costs(
     )
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_refund_products_fulfillment_lines_custom_amount(
     mocked_refund,
     staff_api_client,
@@ -827,7 +827,7 @@ def test_fulfillment_refund_products_fulfillment_lines_custom_amount(
     )
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_refund_products_order_lines_custom_amount(
     mocked_refund,
     staff_api_client,
@@ -878,7 +878,7 @@ def test_fulfillment_refund_products_order_lines_custom_amount(
     )
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_refund_products_fulfillment_lines_and_order_lines(
     mocked_refund,
     warehouse,
@@ -984,7 +984,7 @@ def test_fulfillment_refund_products_fulfillment_lines_and_order_lines(
 
 
 @patch("saleor.order.actions.order_refunded")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_refund_products_calls_order_refunded(
     mocked_refund,
     mocked_order_refunded,

--- a/saleor/graphql/order/tests/mutations/test_fulfillment_return_products.py
+++ b/saleor/graphql/order/tests/mutations/test_fulfillment_return_products.py
@@ -103,7 +103,7 @@ def test_fulfillment_return_products_by_user_no_channel_access(
     assert_no_permission(response)
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_return_products_by_app(
     mocked_refund,
     app_api_client,
@@ -173,7 +173,7 @@ def test_fulfillment_return_products_order_without_payment(
     assert fulfillment is None
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_return_products_amount_and_shipping_costs(
     mocked_refund,
     staff_api_client,
@@ -252,7 +252,7 @@ def test_fulfillment_return_products_amount_order_with_gift_card(
     assert fulfillment is None
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_return_products_refund_raising_payment_error(
     mocked_refund,
     staff_api_client,
@@ -286,7 +286,7 @@ def test_fulfillment_return_products_refund_raising_payment_error(
     assert errors[0]["code"] == OrderErrorCode.CANNOT_REFUND.name
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_return_products_order_lines(
     mocked_refund,
     staff_api_client,
@@ -520,7 +520,7 @@ def test_fulfillment_return_products_order_lines_quantity_bigger_than_unfulfille
     assert return_fulfillment is None
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_return_products_order_lines_custom_amount(
     mocked_refund,
     staff_api_client,
@@ -576,7 +576,7 @@ def test_fulfillment_return_products_order_lines_custom_amount(
     )
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_return_products_fulfillment_lines(
     mocked_refund,
     staff_api_client,
@@ -710,7 +710,7 @@ def test_fulfillment_return_products_fulfillment_lines(
     )
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_return_products_gift_card_fulfillment_line(
     mocked_refund,
     staff_api_client,
@@ -877,7 +877,7 @@ def test_fulfillment_return_products_lines_with_incorrect_status(
     assert return_fulfillment is None
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_return_products_fulfillment_lines_include_shipping_costs(
     mocked_refund,
     staff_api_client,
@@ -938,7 +938,7 @@ def test_fulfillment_return_products_fulfillment_lines_include_shipping_costs(
     )
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_return_products_fulfillment_lines_and_order_lines(
     mocked_refund,
     warehouse,
@@ -1061,7 +1061,7 @@ def test_fulfillment_return_products_fulfillment_lines_and_order_lines(
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.order_refunded")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_return_and_replace_products_calls_order_refunded_and_webhooks(
     mocked_refund,
     mocked_order_refunded,
@@ -1151,7 +1151,7 @@ def test_fulfillment_return_and_replace_products_calls_order_refunded_and_webhoo
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.order_refunded")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_fulfillment_return_products_calls_order_refunded_and_webhooks(
     mocked_refund,
     mocked_order_refunded,

--- a/saleor/graphql/page/tests/queries/test_pages.py
+++ b/saleor/graphql/page/tests/queries/test_pages.py
@@ -141,7 +141,7 @@ def test_pages_query_with_filter_by_page_type(
     [
         ({"slugs": ["test-url-1"]}, 1),
         ({"slugs": ["test-url-1", "test-url-2"]}, 2),
-        ({"slugs": []}, 2),
+        ({"slugs": []}, 4),
     ],
 )
 def test_pages_with_filtering(filter_by, pages_count, staff_api_client, page_list):

--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -18,7 +18,6 @@ from .....payment.interface import PaymentMethodDetails
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
 from .....payment.utils import (
     create_manual_adjustment_events,
-    process_order_or_checkout_with_transaction,
     truncate_transaction_event_message,
     update_transaction_item_with_payment_method_details,
 )
@@ -41,6 +40,7 @@ from .shared import (
     get_payment_method_details,
     validate_payment_method_details_input,
 )
+from .utils import process_order_or_checkout_with_transaction
 
 if TYPE_CHECKING:
     pass

--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -25,7 +25,6 @@ from .....payment.utils import (
     create_failed_transaction_event,
     get_already_existing_event,
     get_transaction_event_amount,
-    process_order_or_checkout_with_transaction,
     truncate_transaction_event_message,
     update_transaction_item_with_payment_method_details,
 )
@@ -53,7 +52,7 @@ from .shared import (
     get_payment_method_details,
     validate_payment_method_details_input,
 )
-from .utils import get_transaction_item
+from .utils import get_transaction_item, process_order_or_checkout_with_transaction
 
 if TYPE_CHECKING:
     from .....plugins.manager import PluginsManager

--- a/saleor/graphql/payment/mutations/transaction/transaction_update.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_update.py
@@ -18,7 +18,6 @@ from .....payment.transaction_item_calculations import (
 )
 from .....payment.utils import (
     create_manual_adjustment_events,
-    process_order_or_checkout_with_transaction,
     update_transaction_item_with_payment_method_details,
 )
 from .....permission.auth_filters import AuthorizationFilters
@@ -38,7 +37,7 @@ from .transaction_create import (
     TransactionCreateInput,
     TransactionEventInput,
 )
-from .utils import get_transaction_item
+from .utils import get_transaction_item, process_order_or_checkout_with_transaction
 
 if TYPE_CHECKING:
     from .....account.models import User
@@ -255,6 +254,8 @@ class TransactionUpdate(TransactionCreate):
                     message=transaction_event.get("message", ""),
                 )
 
+        # TransactionCreate.process_order_or_checkout_with_transaction is called to use same logic for processing
+        # order or checkout as in a transaction mutation.
         process_order_or_checkout_with_transaction(
             instance,
             manager,

--- a/saleor/graphql/payment/mutations/transaction/utils.py
+++ b/saleor/graphql/payment/mutations/transaction/utils.py
@@ -1,14 +1,41 @@
+from decimal import Decimal
+from typing import TYPE_CHECKING, cast
+from uuid import UUID
+
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_ipv46_address
 
+from .....account.models import User
+from .....app.models import App
+from .....checkout.actions import (
+    transaction_amounts_for_checkout_updated_without_price_recalculation,
+)
 from .....core.exceptions import PermissionDenied
+from .....core.tracing import traced_atomic_transaction
 from .....core.utils import get_client_ip
+from .....order import OrderStatus
+from .....order import models as order_models
+from .....order.actions import order_transaction_updated
+from .....order.fetch import fetch_order_info
+from .....order.search import update_order_search_vector
+from .....order.utils import (
+    calculate_order_granted_refund_status,
+    refresh_order_status,
+    updates_amounts_for_order,
+)
 from .....payment import models as payment_models
 from .....payment.error_codes import TransactionUpdateErrorCode
+from .....payment.lock_objects import (
+    get_checkout_and_transaction_item_locked_for_update,
+    get_order_and_transaction_item_locked_for_update,
+)
 from .....permission.enums import PaymentPermissions
 from ....app.dataloaders import get_app_promise
 from ....core.utils import from_global_id_or_error
 from ...types import TransactionItem
+
+if TYPE_CHECKING:
+    from .....plugins.manager import PluginsManager
 
 
 def get_transaction_item(
@@ -73,3 +100,97 @@ def clean_customer_ip_address(info, customer_ip_address: str | None, error_code:
             }
         ) from e
     return customer_ip_address
+
+
+def process_order_with_transaction(
+    transaction: payment_models.TransactionItem,
+    manager: "PluginsManager",
+    user: User | None,
+    app: App | None,
+    previous_authorized_value: Decimal = Decimal(0),
+    previous_charged_value: Decimal = Decimal(0),
+    previous_refunded_value: Decimal = Decimal(0),
+    related_granted_refund: order_models.OrderGrantedRefund | None = None,
+):
+    order = None
+    # This is executed after we ensure that the transaction is not a checkout
+    # transaction, so we can safely cast the order_id to UUID.
+    order_id = cast(UUID, transaction.order_id)
+    with traced_atomic_transaction():
+        order, transaction = get_order_and_transaction_item_locked_for_update(
+            order_id, transaction.pk
+        )
+        update_fields = []
+        updates_amounts_for_order(order, save=False)
+        update_fields.extend(
+            [
+                "total_charged_amount",
+                "charge_status",
+                "total_authorized_amount",
+                "authorize_status",
+            ]
+        )
+        if (
+            order.channel.automatically_confirm_all_new_orders
+            and order.status == OrderStatus.UNCONFIRMED
+        ):
+            status_updated = refresh_order_status(order)
+            if status_updated:
+                update_fields.append("status")
+        if update_fields:
+            update_fields.append("updated_at")
+            order.save(update_fields=update_fields)
+
+    update_order_search_vector(order)
+    order_info = fetch_order_info(order)
+    order_transaction_updated(
+        order_info=order_info,
+        transaction_item=transaction,
+        manager=manager,
+        user=user,
+        app=app,
+        previous_authorized_value=previous_authorized_value,
+        previous_charged_value=previous_charged_value,
+        previous_refunded_value=previous_refunded_value,
+    )
+    if related_granted_refund:
+        calculate_order_granted_refund_status(related_granted_refund)
+
+
+def process_order_or_checkout_with_transaction(
+    transaction: payment_models.TransactionItem,
+    manager: "PluginsManager",
+    user: User | None,
+    app: App | None,
+    previous_authorized_value: Decimal = Decimal(0),
+    previous_charged_value: Decimal = Decimal(0),
+    previous_refunded_value: Decimal = Decimal(0),
+    related_granted_refund: order_models.OrderGrantedRefund | None = None,
+):
+    checkout_deleted = False
+    if transaction.checkout_id:
+        with traced_atomic_transaction():
+            locked_checkout, transaction = (
+                get_checkout_and_transaction_item_locked_for_update(
+                    transaction.checkout_id, transaction.pk
+                )
+            )
+            if transaction.checkout_id and locked_checkout:
+                transaction_amounts_for_checkout_updated_without_price_recalculation(
+                    transaction, locked_checkout, manager, user, app
+                )
+            else:
+                checkout_deleted = True
+                # If the checkout was deleted, we still want to update the order associated with the transaction.
+
+    if transaction.order_id or checkout_deleted:
+        process_order_with_transaction(
+            transaction,
+            manager,
+            user,
+            app,
+            previous_authorized_value,
+            previous_charged_value,
+            previous_refunded_value,
+            related_granted_refund=related_granted_refund,
+        )

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -2796,7 +2796,7 @@ def test_transaction_create_with_invalid_other_payment_method_details(
 # Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
 @pytest.mark.django_db(transaction=True)
 @patch(
-    "saleor.payment.utils.get_order_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_order_and_transaction_item_locked_for_update",
     wraps=get_order_and_transaction_item_locked_for_update,
 )
 def test_lock_order_during_updating_order_amounts(
@@ -2842,7 +2842,7 @@ def test_lock_order_during_updating_order_amounts(
 # Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
 @pytest.mark.django_db(transaction=True)
 @patch(
-    "saleor.payment.utils.get_checkout_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_checkout_and_transaction_item_locked_for_update",
     wraps=get_checkout_and_transaction_item_locked_for_update,
 )
 def test_lock_checkout_during_updating_checkout_amounts(
@@ -2898,7 +2898,7 @@ def test_lock_checkout_during_updating_checkout_amounts(
     )
 
 
-def test_transaction_create_checkout_completed_race_condition(
+def test_transaction_create_create_checkout_completed_race_condition(
     app_api_client,
     permission_manage_payments,
     checkout_with_prices,

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -3341,7 +3341,7 @@ def test_transaction_event_report_empty_message(
 
 
 @patch(
-    "saleor.payment.utils.get_order_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_order_and_transaction_item_locked_for_update",
     wraps=get_order_and_transaction_item_locked_for_update,
 )
 def test_lock_order_during_updating_order_amounts(
@@ -3405,7 +3405,7 @@ def test_lock_order_during_updating_order_amounts(
 
 
 @patch(
-    "saleor.payment.utils.get_checkout_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_checkout_and_transaction_item_locked_for_update",
     wraps=get_checkout_and_transaction_item_locked_for_update,
 )
 def test_lock_checkout_during_updating_checkout_amounts(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -11,11 +11,10 @@ from freezegun import freeze_time
 from .....channel import TransactionFlowStrategy
 from .....checkout import CheckoutAuthorizeStatus, CheckoutChargeStatus
 from .....checkout.calculations import fetch_checkout_data
-from .....checkout.complete_checkout import create_order_from_checkout
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout
 from .....core.prices import quantize_price
-from .....order import OrderAuthorizeStatus, OrderChargeStatus, OrderEvents, OrderStatus
+from .....order import OrderChargeStatus, OrderEvents, OrderStatus
 from .....order.models import Order
 from .....payment import TransactionEventType, TransactionItemIdempotencyUniqueError
 from .....payment.interface import (
@@ -24,12 +23,7 @@ from .....payment.interface import (
     TransactionSessionData,
     TransactionSessionResult,
 )
-from .....payment.lock_objects import (
-    get_checkout_and_transaction_item_locked_for_update,
-    get_order_and_transaction_item_locked_for_update,
-)
 from .....payment.models import Payment, TransactionItem
-from .....tests import race_condition
 from .....webhook.event_types import WebhookEventSyncType
 from ....channel.enums import TransactionFlowStrategyEnum
 from ....core.enums import TransactionInitializeErrorCode
@@ -2970,189 +2964,3 @@ def test_for_order_with_tax_app(
     for call in mocked_send_webhook_request_sync.mock_calls:
         delivery = call.args[0]
         assert delivery.payload.get_payload()
-
-
-# Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
-@pytest.mark.django_db(transaction=True)
-@mock.patch(
-    "saleor.payment.utils.get_order_and_transaction_item_locked_for_update",
-    wraps=get_order_and_transaction_item_locked_for_update,
-)
-@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
-def test_lock_order_during_updating_order_amounts(
-    mocked_initialize,
-    mocked_get_order_and_transaction_item_locked_for_update,
-    user_api_client,
-    unconfirmed_order_with_lines,
-    webhook_app,
-    transaction_session_response,
-):
-    # given
-    order = unconfirmed_order_with_lines
-    expected_app_identifier = "webhook.app.identifier"
-    webhook_app.identifier = expected_app_identifier
-    webhook_app.save()
-
-    expected_psp_reference = "ppp-123"
-    expected_response = transaction_session_response.copy()
-    expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
-    expected_response["amount"] = str(order.total_gross_amount)
-    expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = TransactionSessionResult(
-        app_identifier=expected_app_identifier, response=expected_response
-    )
-
-    variables = {
-        "amount": order.total_gross_amount,
-        "id": to_global_id_or_none(order),
-        "paymentGateway": {"id": expected_app_identifier, "data": None},
-    }
-
-    # when
-    response = user_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
-
-    # then
-    content = get_graphql_content(response)
-    _assert_fields(
-        content=content,
-        source_object=order,
-        expected_amount=order.total_gross_amount,
-        expected_psp_reference=expected_psp_reference,
-        response_event_type=TransactionEventType.CHARGE_SUCCESS,
-        app_identifier=webhook_app.identifier,
-        mocked_initialize=mocked_initialize,
-        charged_value=order.total_gross_amount,
-        returned_data=expected_response["data"],
-    )
-
-    assert not order.is_fully_paid()
-    order.refresh_from_db()
-    assert order.is_fully_paid()
-    assert order.total_authorized_amount == Decimal(0)
-    assert order.total_charged_amount == order.total_gross_amount
-    assert order.charge_status == OrderChargeStatus.FULL
-    assert order.authorize_status == OrderAuthorizeStatus.FULL
-    transaction_pk = order.payment_transactions.get().pk
-    mocked_get_order_and_transaction_item_locked_for_update.assert_called_once_with(
-        order.pk, transaction_pk
-    )
-
-
-# Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
-@pytest.mark.django_db(transaction=True)
-@mock.patch(
-    "saleor.payment.utils.get_checkout_and_transaction_item_locked_for_update",
-    wraps=get_checkout_and_transaction_item_locked_for_update,
-)
-@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
-def test_lock_checkout_during_updating_checkout_amounts(
-    mocked_initialize,
-    mocked_get_checkout_and_transaction_item_locked_for_update,
-    user_api_client,
-    checkout_with_prices,
-    webhook_app,
-    transaction_session_response,
-    plugins_manager,
-):
-    # given
-    checkout = checkout_with_prices
-    lines, _ = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
-    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
-    expected_app_identifier = "webhook.app.identifier"
-    webhook_app.identifier = expected_app_identifier
-    webhook_app.save()
-
-    expected_psp_reference = "ppp-123"
-    expected_response = transaction_session_response.copy()
-    expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
-    expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
-    expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = TransactionSessionResult(
-        app_identifier=expected_app_identifier, response=expected_response
-    )
-
-    variables = {
-        "action": None,
-        "amount": None,
-        "id": to_global_id_or_none(checkout),
-        "paymentGateway": {"id": expected_app_identifier, "data": None},
-    }
-
-    # when
-    response = user_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
-
-    # then
-    content = get_graphql_content(response)
-    checkout.refresh_from_db()
-    _assert_fields(
-        content=content,
-        source_object=checkout,
-        expected_amount=checkout.total_gross_amount,
-        expected_psp_reference=expected_psp_reference,
-        response_event_type=TransactionEventType.CHARGE_SUCCESS,
-        app_identifier=webhook_app.identifier,
-        mocked_initialize=mocked_initialize,
-        charged_value=checkout.total_gross_amount,
-        returned_data=expected_response["data"],
-    )
-    assert checkout.charge_status == CheckoutChargeStatus.FULL
-    assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
-    transaction_pk = checkout.payment_transactions.get().pk
-    mocked_get_checkout_and_transaction_item_locked_for_update.assert_called_once_with(
-        checkout.pk, transaction_pk
-    )
-
-
-@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
-def test_transaction_initialize_checkout_completed_race_condition(
-    mocked_initialize,
-    user_api_client,
-    checkout_with_prices,
-    webhook_app,
-    transaction_session_response,
-    plugins_manager,
-):
-    # given
-    checkout = checkout_with_prices
-    lines, _ = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
-    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
-    expected_app_identifier = "webhook.app.identifier"
-    webhook_app.identifier = expected_app_identifier
-    webhook_app.save()
-
-    expected_psp_reference = "ppp-123"
-    expected_response = transaction_session_response.copy()
-    expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
-    expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
-    expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = TransactionSessionResult(
-        app_identifier=expected_app_identifier, response=expected_response
-    )
-
-    variables = {
-        "action": None,
-        "amount": None,
-        "id": to_global_id_or_none(checkout),
-        "paymentGateway": {"id": expected_app_identifier, "data": None},
-    }
-
-    # when
-    def complete_checkout(*args, **kwargs):
-        create_order_from_checkout(
-            checkout_info, plugins_manager, user=user_api_client.user, app=None
-        )
-
-    with race_condition.RunBefore(
-        "saleor.payment.utils.recalculate_transaction_amounts",
-        complete_checkout,
-    ):
-        user_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
-
-    # then
-    order = Order.objects.get(checkout_token=checkout.pk)
-    assert order.status == OrderStatus.UNFULFILLED
-    assert order.charge_status == OrderChargeStatus.FULL
-    assert order.authorize_status == OrderAuthorizeStatus.FULL
-    assert order.total_charged.amount == checkout.total.gross.amount

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -3760,7 +3760,7 @@ def test_transaction_update_with_invalid_other_payment_method_details(
 # Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
 @pytest.mark.django_db(transaction=True)
 @patch(
-    "saleor.payment.utils.get_order_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_order_and_transaction_item_locked_for_update",
     wraps=get_order_and_transaction_item_locked_for_update,
 )
 def test_lock_order_during_updating_order_amounts(
@@ -3810,7 +3810,7 @@ def test_lock_order_during_updating_order_amounts(
 # Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
 @pytest.mark.django_db(transaction=True)
 @patch(
-    "saleor.payment.utils.get_checkout_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_checkout_and_transaction_item_locked_for_update",
     wraps=get_checkout_and_transaction_item_locked_for_update,
 )
 def test_lock_checkout_during_updating_checkout_amounts(
@@ -3864,7 +3864,7 @@ def test_lock_checkout_during_updating_checkout_amounts(
     )
 
 
-def test_transaction_update_checkout_completed_race_condition(
+def test_transaction_create_create_checkout_completed_race_condition(
     app_api_client,
     permission_manage_payments,
     checkout_with_prices,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13033,6 +13033,42 @@ input AttributeValuePageInput {
 
   """Filter by boolean value for attributes of boolean type."""
   boolean: Boolean
+
+  """Filter by reference attribute value."""
+  reference: ReferenceAttributeWhereInput
+}
+
+input ReferenceAttributeWhereInput {
+  """
+  Returns objects with a reference pointing to an object identified by the given ID.
+  """
+  referencedIds: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a page identified by the given slug.
+  """
+  pageSlugs: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a product identified by the given slug.
+  """
+  productSlugs: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a product variant identified by the given sku.
+  """
+  productVariantSkus: ContainsFilterInput
+}
+
+"""
+Define the filtering options for fields that can contain multiple values.
+"""
+input ContainsFilterInput {
+  """The field contains at least one of the specified values."""
+  containsAny: [String!]
+
+  """The field contains all of the specified values."""
+  containsAll: [String!]
 }
 
 type PageTypeCountableConnection @doc(category: "Pages") {

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -29,9 +29,11 @@ from ..payment import (
     PaymentError,
     TransactionAction,
     TransactionKind,
+    gateway,
 )
 from ..payment.interface import RefundData
 from ..payment.models import Payment, Transaction, TransactionItem
+from ..payment.utils import create_payment, create_transaction_for_order
 from ..plugins.manager import PluginsManager
 from ..shipping.models import ShippingMethodChannelListing
 from ..warehouse.management import (
@@ -935,9 +937,6 @@ def mark_order_as_paid_with_transaction(
     Allows to create a transaction for an order.
     """
     with transaction.atomic():
-        # Circular imports
-        from ..payment.utils import create_transaction_for_order
-
         create_transaction_for_order(
             order=order,
             user=request_user,
@@ -979,9 +978,6 @@ def mark_order_as_paid_with_payment(
     # transaction ensures that webhooks are triggered when payments and transactions are
     # properly created
     with traced_atomic_transaction():
-        # Circular imports
-        from ..payment.utils import create_payment
-
         payment = create_payment(
             gateway=CustomPaymentChoices.MANUAL,
             payment_token="",
@@ -2043,10 +2039,7 @@ def _process_refund(
             amount += order.shipping_price_gross_amount
     if amount and payment:
         amount = min(payment.captured_amount, amount)
-        # Circular imports
-        from ..payment.gateway import refund
-
-        refund(
+        gateway.refund(
             payment,
             manager,
             amount=amount,

--- a/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
+++ b/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
@@ -14,7 +14,7 @@ from ..models import Fulfillment, FulfillmentLine
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines(
     mocked_refund,
     mocked_order_updated,
@@ -92,7 +92,7 @@ def test_create_return_fulfillment_only_order_lines(
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_with_refund(
     mocked_refund,
     mocked_order_updated,
@@ -172,7 +172,7 @@ def test_create_return_fulfillment_only_order_lines_with_refund(
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
     mocked_refund,
     mocked_order_updated,
@@ -258,7 +258,7 @@ def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_with_replace_request(
     mocked_refund,
     mocked_order_updated,
@@ -393,7 +393,7 @@ def test_create_return_fulfillment_only_order_lines_with_replace_request(
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_fulfillment_lines(
     mocked_refund,
     mocked_order_updated,
@@ -444,7 +444,7 @@ def test_create_return_fulfillment_only_fulfillment_lines(
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_fulfillment_lines_replace_order(
     mocked_refund,
     mocked_order_updated,
@@ -555,7 +555,7 @@ def test_create_return_fulfillment_only_fulfillment_lines_replace_order(
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_with_lines_already_refunded(
     mocked_refund,
     mocked_order_updated,
@@ -668,7 +668,7 @@ def test_create_return_fulfillment_with_lines_already_refunded(
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_with_old_ids(
     mocked_refund,
     mocked_order_updated,

--- a/saleor/order/tests/test_order_actions_refund_products.py
+++ b/saleor/order/tests/test_order_actions_refund_products.py
@@ -12,7 +12,7 @@ from ..models import FulfillmentLine
 
 
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_create_refund_fulfillment_only_order_lines(
     mocked_refund,
     mocked_order_updated,
@@ -86,7 +86,7 @@ def test_create_refund_fulfillment_only_order_lines(
 
 
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_create_refund_fulfillment_included_shipping_costs(
     mocked_refund,
     mocked_order_updated,
@@ -152,7 +152,7 @@ def test_create_refund_fulfillment_included_shipping_costs(
 
 
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_create_refund_fulfillment_only_fulfillment_lines(
     mocked_refund,
     mocked_order_updated,
@@ -213,7 +213,7 @@ def test_create_refund_fulfillment_only_fulfillment_lines(
 
 
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 def test_create_refund_fulfillment_custom_amount(
     mocked_refund,
     mocked_order_updated,

--- a/saleor/page/tests/fixtures/page.py
+++ b/saleor/page/tests/fixtures/page.py
@@ -63,7 +63,23 @@ def page_list(db, page_type):
         "is_published": True,
         "page_type": page_type,
     }
-    pages = Page.objects.bulk_create([Page(**data_1), Page(**data_2)])
+    data_3 = {
+        "slug": "test3",
+        "title": "Test page3",
+        "content": dummy_editorjs("Test content."),
+        "is_published": True,
+        "page_type": page_type,
+    }
+    data_4 = {
+        "slug": "test4",
+        "title": "Test page4",
+        "content": dummy_editorjs("Test content."),
+        "is_published": True,
+        "page_type": page_type,
+    }
+    pages = Page.objects.bulk_create(
+        [Page(**data_1), Page(**data_2), Page(**data_3), Page(**data_4)]
+    )
     return pages
 
 

--- a/saleor/payment/gateways/np_atobarai/tests/conftest.py
+++ b/saleor/payment/gateways/np_atobarai/tests/conftest.py
@@ -157,7 +157,7 @@ def create_refund(payment_dummy):
             payment.captured_amount -= amount
             payment.save(update_fields=["captured_amount"])
 
-        with patch("saleor.payment.gateway.refund", side_effect=mocked_refund):
+        with patch("saleor.order.actions.gateway.refund", side_effect=mocked_refund):
             return create_refund_fulfillment(
                 user=None,
                 app=None,

--- a/saleor/payment/gateways/np_atobarai/tests/test_utils.py
+++ b/saleor/payment/gateways/np_atobarai/tests/test_utils.py
@@ -201,7 +201,7 @@ def test_create_refunded_lines_fulfillment_lines(fulfilled_order):
     }
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 @pytest.mark.parametrize("previous_refund_shipping_costs", [True, False])
 def test_create_refunded_lines_previously_refunded_order_lines(
     _mocked_refund,
@@ -247,7 +247,7 @@ def test_create_refunded_lines_previously_refunded_order_lines(
     assert lines == {line.line.variant_id: line.quantity for line in order_refund_lines}
 
 
-@patch("saleor.payment.gateway.refund")
+@patch("saleor.order.actions.gateway.refund")
 @pytest.mark.parametrize("previous_refund_shipping_costs", [True, False])
 def test_create_refunded_lines_previously_refunded_fulfillment_lines(
     _mocked_refund,

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -2,7 +2,6 @@ import json
 import logging
 from decimal import Decimal
 from typing import Any, Optional, cast, get_args, overload
-from uuid import UUID
 
 import graphene
 from babel.numbers import get_currency_precision
@@ -20,7 +19,6 @@ from ..channel import TransactionFlowStrategy
 from ..checkout import calculations
 from ..checkout.actions import (
     transaction_amounts_for_checkout_updated,
-    transaction_amounts_for_checkout_updated_without_price_recalculation,
     update_last_transaction_modified_at_for_checkout,
 )
 from ..checkout.fetch import fetch_checkout_info, fetch_checkout_lines
@@ -30,14 +28,11 @@ from ..core.db.connection import allow_writer
 from ..core.prices import quantize_price
 from ..core.tracing import traced_atomic_transaction
 from ..graphql.core.utils import str_to_enum
-from ..order import OrderStatus
-from ..order.actions import order_transaction_updated
 from ..order.fetch import fetch_order_info
 from ..order.models import Order, OrderGrantedRefund
 from ..order.search import update_order_search_vector
 from ..order.utils import (
     calculate_order_granted_refund_status,
-    refresh_order_status,
     update_order_authorize_data,
     updates_amounts_for_order,
 )
@@ -72,10 +67,6 @@ from .interface import (
     TransactionRequestResponse,
     TransactionSessionData,
     TransactionSessionResponse,
-)
-from .lock_objects import (
-    get_checkout_and_transaction_item_locked_for_update,
-    get_order_and_transaction_item_locked_for_update,
 )
 from .models import Payment, Transaction, TransactionEvent, TransactionItem
 from .transaction_item_calculations import recalculate_transaction_amounts
@@ -1314,100 +1305,6 @@ def update_transaction_item_with_payment_method_details(
     return updated_fields
 
 
-def process_order_with_transaction(
-    transaction: TransactionItem,
-    manager: "PluginsManager",
-    user: Optional["User"],
-    app: Optional["App"],
-    previous_authorized_value: Decimal = Decimal(0),
-    previous_charged_value: Decimal = Decimal(0),
-    previous_refunded_value: Decimal = Decimal(0),
-    related_granted_refund: OrderGrantedRefund | None = None,
-):
-    order = None
-    # This is executed after we ensure that the transaction is not a checkout
-    # transaction, so we can safely cast the order_id to UUID.
-    order_id = cast(UUID, transaction.order_id)
-    with traced_atomic_transaction():
-        order, transaction = get_order_and_transaction_item_locked_for_update(
-            order_id, transaction.pk
-        )
-        update_fields = []
-        updates_amounts_for_order(order, save=False)
-        update_fields.extend(
-            [
-                "total_charged_amount",
-                "charge_status",
-                "total_authorized_amount",
-                "authorize_status",
-            ]
-        )
-        if (
-            order.channel.automatically_confirm_all_new_orders
-            and order.status == OrderStatus.UNCONFIRMED
-        ):
-            status_updated = refresh_order_status(order)
-            if status_updated:
-                update_fields.append("status")
-        if update_fields:
-            update_fields.append("updated_at")
-            order.save(update_fields=update_fields)
-
-    update_order_search_vector(order)
-    order_info = fetch_order_info(order)
-    order_transaction_updated(
-        order_info=order_info,
-        transaction_item=transaction,
-        manager=manager,
-        user=user,
-        app=app,
-        previous_authorized_value=previous_authorized_value,
-        previous_charged_value=previous_charged_value,
-        previous_refunded_value=previous_refunded_value,
-    )
-    if related_granted_refund:
-        calculate_order_granted_refund_status(related_granted_refund)
-
-
-def process_order_or_checkout_with_transaction(
-    transaction: TransactionItem,
-    manager: "PluginsManager",
-    user: Optional["User"],
-    app: Optional["App"],
-    previous_authorized_value: Decimal = Decimal(0),
-    previous_charged_value: Decimal = Decimal(0),
-    previous_refunded_value: Decimal = Decimal(0),
-    related_granted_refund: OrderGrantedRefund | None = None,
-):
-    checkout_deleted = False
-    if transaction.checkout_id:
-        with traced_atomic_transaction():
-            locked_checkout, transaction = (
-                get_checkout_and_transaction_item_locked_for_update(
-                    transaction.checkout_id, transaction.pk
-                )
-            )
-            if transaction.checkout_id and locked_checkout:
-                transaction_amounts_for_checkout_updated_without_price_recalculation(
-                    transaction, locked_checkout, manager, user, app
-                )
-            else:
-                checkout_deleted = True
-                # If the checkout was deleted, we still want to update the order associated with the transaction.
-
-    if transaction.order_id or checkout_deleted:
-        process_order_with_transaction(
-            transaction,
-            manager,
-            user,
-            app,
-            previous_authorized_value,
-            previous_charged_value,
-            previous_refunded_value,
-            related_granted_refund=related_granted_refund,
-        )
-
-
 def create_transaction_event_for_transaction_session(
     request_event: TransactionEvent,
     app: App,
@@ -1510,17 +1407,27 @@ def create_transaction_event_for_transaction_session(
             ]
             + transaction_item_updated_fields
         )
+        if transaction_item.order_id:
+            # circular import
+            from ..order.actions import order_transaction_updated
 
-        process_order_or_checkout_with_transaction(
-            transaction_item,
-            manager,
-            None,
-            app,
-            previous_authorized_value=previous_authorized_value,
-            previous_charged_value=previous_charged_value,
-            previous_refunded_value=previous_refunded_value,
-        )
-
+            update_order_with_transaction_details(transaction_item)
+            order = cast(Order, transaction_item.order)
+            order_info = fetch_order_info(order)
+            order_transaction_updated(
+                order_info=order_info,
+                transaction_item=transaction_item,
+                manager=manager,
+                user=None,
+                app=app,
+                previous_authorized_value=previous_authorized_value,
+                previous_charged_value=previous_charged_value,
+                previous_refunded_value=previous_refunded_value,
+            )
+        elif transaction_item.checkout_id:
+            transaction_amounts_for_checkout_updated(
+                transaction_item, manager, app=app, user=None
+            )
     elif event.psp_reference and transaction_item.psp_reference != event.psp_reference:
         transaction_item.psp_reference = event.psp_reference
         transaction_item.save(


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/17967

I want to merge this change because it adds support  to reference attributes.
It itroduces:
- `contains` structures to support approaches like contain all, or contain any
  -  `containsAll` - return the records that have all listed references
  - `containsAny` - return the records that have at least sinlge reference
- search by the slug of referenced variant, product or page

Input like below:
```graphql
{
  pages(
    first:100
    where: {
      attributes:[
        {
          ...